### PR TITLE
multiple runs of the same simulation settings

### DIFF
--- a/a9_fake_news_simulator/environment.py
+++ b/a9_fake_news_simulator/environment.py
@@ -287,17 +287,19 @@ class Environment:
         results = results.join(pd.DataFrame({"#steps": self.num_steps}, index=[0]))
         return results
 
-    # initiates the simulation
-    def run_simulation(self):
-        print(">> Initial configurations:")
-        self.simulations_stats()
-        print("<< Beginning simulation >>")
+    # runs the simulation
+    def run_simulation(self, verbose=False):
+        if verbose:  # prints only if explicitly stated
+            print(">> Initial configurations:")
+            self.simulations_stats()
+            print("<< Beginning simulation >>")
         for step in tqdm(range(self.num_steps)):
             self.run_communication_protocol()
             # print(self.output_measures(step))
-        print("<< END OF SIMULATION >>")
-        self.simulations_stats(printing=True)
-        print(self.output_measures())
+        if verbose:  # prints only if explicitly stated
+            print("<< END OF SIMULATION >>")
+            self.simulations_stats(printing=True)
+        return self.output_measures()
 
     # calculates distance
     def distance(self, xy1, xy2):

--- a/a9_fake_news_simulator/main.py
+++ b/a9_fake_news_simulator/main.py
@@ -1,4 +1,5 @@
 import sys
+import pandas as pd
 from cmd import Cmd
 
 # User defined Imports ugly python import syntax >:(
@@ -202,15 +203,21 @@ class MyPrompt(Cmd):
         if inp == 'x' or inp == 'q':
             return self.do_exit(inp)
         if inp == 'c' or inp == 'start':
-            network = environment.Environment(args['n_agents'], args['n_liars'], args['n_experts'],
-                                              args['n_connections'], args['cluster_distance'], args['n_news'], args['n_steps'],
-                                              args['communication_protocol'], args['conversation_protocol'])
-            print(network.clustering_coefficient())
-            network.run_simulation()
+            # initialize dataframe to keep the results of each run
+            run_results_df = pd.DataFrame()
+            for run in range(1, args['runs']+1):
+                network = environment.Environment(args['n_agents'], args['n_liars'], args['n_experts'],
+                                                  args['n_connections'], args['cluster_distance'], args['n_news'], args['n_steps'],
+                                                  args['communication_protocol'], args['conversation_protocol'])
+                # combine run results with existing ones
+                run_results_df = pd.concat([run_results_df, network.run_simulation()])
+            # print results dataframe on terminal
+            print(run_results_df)
         if inp == 'show_values':
             self.do_show_values()
         if inp == 'show_description':
             self.do_show_description()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A simulation is initiated and run multiple times.
A simulation run now returns a dataframe with its results.
Prints inside the simulation run are silent to avoid an overflow of prints. Set 'verbose' to true to get the prints for every simulation run.